### PR TITLE
Added a human-readable TypeScript type definition generator.

### DIFF
--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -4,6 +4,7 @@ import "dart:io";
 import "dart:async";
 import "dart:convert";
 
+import "package:calzone/compiler.dart";
 import "package:calzone/patcher.dart";
 import "package:calzone/util.dart";
 
@@ -30,6 +31,7 @@ class Builder {
 
   final List<String> include;
   final List<TypeTransformer> typeTransformers;
+  final List<CompilerVisitor> compilerVisitors;
 
   final String dartFile;
   final String directory;
@@ -40,6 +42,7 @@ class Builder {
       {this.stage: BuilderStage.ALL,
       this.target: PatcherTarget.NODE,
       this.typeTransformers: const [],
+      this.compilerVisitors: const [],
       this.directory: "temp",
       this.isMinified: true})
       : this.include = include is List<String>
@@ -73,7 +76,9 @@ class Builder {
 
       var compiler = new Compiler(
           dartFile, "$directory/index.js.info.json", mangledNames,
-          typeTransformers: typeTransformers, isMinified: isMinified);
+          typeTransformers: typeTransformers,
+          compilerVisitors: compilerVisitors,
+          isMinified: isMinified);
 
       LOGGER.fine("Compiling wrapper for dart2js output");
       var str = compiler.compile(include);

--- a/lib/compiler.dart
+++ b/lib/compiler.dart
@@ -252,7 +252,7 @@ class InfoParent extends _JSONWrapper {
   }
 
   String getField(String name, Class c, List<String> fields) {
-    if (fields.length == 0) throw fields;
+    if (fields.isEmpty) throw fields;
 
     String value = "";
     int index = 0;
@@ -267,7 +267,7 @@ class InfoParent extends _JSONWrapper {
       index++;
     }
 
-    if (value.length == 0) throw childValues.length;
+    if (value.isEmpty) throw childValues.length;
     return value;
   }
 }
@@ -315,14 +315,14 @@ List<Parameter> _getParamsFromInfo(Compiler compiler, Map<String, dynamic> data,
   var isOptional = false;
   var isPositional = false;
 
-  if (type.length <= 0) {
+  if (type.isEmpty) {
     return [];
   }
 
   List<String> p = type.split(_COMMA_REGEX)
-    ..removeWhere((piece) => piece.trim().length == 0);
+    ..removeWhere((piece) => piece.trim().isEmpty);
   
-  if (p == null || p.length == 0) {
+  if (p == null || p.isEmpty) {
     return [];
   }
   
@@ -386,7 +386,7 @@ List<Parameter> _getParamsFromInfo(Compiler compiler, Map<String, dynamic> data,
       actualName = split[1];
     } else {
       var c = _getTypeTree(split[0])[0];
-      if (c != "Function" && c != "List" && c != "Iterable" && c != "Map" && 
+      if (!(const ["Function", "List", "Iterable", "Map"].contains(c)) &&
           !compiler.classes.containsKey(c) &&
           c != "dynamic" &&
           !PRIMITIVES.contains(c) &&

--- a/lib/compiler.dart
+++ b/lib/compiler.dart
@@ -20,7 +20,9 @@ abstract class CompilerVisitor {
   
   void addTopLevelFunction(Map<String, dynamic> data, List<Parameter> parameters, String returnType);
   
-  void startClass(Map<String, dynamic> data);
+  void addAbstractClass(Map<String, dynamic> data);
+  
+  void startClass(Map<String, dynamic> data, List<String> inheritedFrom);
   
   void addClassConstructor(Map<String, dynamic> data, List<Parameter> parameters);
   
@@ -324,8 +326,8 @@ List<Parameter> _getParamsFromInfo(Compiler compiler, Map<String, dynamic> data,
     return [];
   }
   
+  int index = 0;
   List<Parameter> parameters = p.map((String piece) {
-    int index = p.indexOf(piece);
     piece = piece.trim();
 
     if (piece.startsWith("[")) {
@@ -407,6 +409,7 @@ List<Parameter> _getParamsFromInfo(Compiler compiler, Map<String, dynamic> data,
         ? ParameterKind.NAMED
         : (isPositional ? ParameterKind.POSITIONAL : ParameterKind.REQUIRED);
 
+    index++;
     return new Parameter(kind, piece, actualName);
   }).toList();
 

--- a/lib/src/analysis/visitor.dart
+++ b/lib/src/analysis/visitor.dart
@@ -26,16 +26,17 @@ class AnalyzerVisitor extends Visitor<Map> {
       var setters = [];
 
       var tree = [];
+      var implementsTree = [];
 
       if (node.extendsClause != null)
         tree.add(node.extendsClause.superclass.toString());
 
-      if (node.implementsClause != null)
-        tree.addAll(
-            node.implementsClause.interfaces.map((type) => type.toString()));
-
       if (node.withClause != null)
         tree.addAll(node.withClause.mixinTypes.map((type) => type.toString()));
+
+      if (node.implementsClause != null)
+        implementsTree.addAll(
+            node.implementsClause.interfaces.map((type) => type.toString()));
 
       var fields = node.members
           .where((member) => member is FieldDeclaration && member.isStatic);
@@ -54,6 +55,7 @@ class AnalyzerVisitor extends Visitor<Map> {
       data[node.name.toString()] = new Class(node.name.toString(), libraryName,
           staticFields: staticFields,
           inheritedFrom: tree,
+          implementsFrom: implementsTree,
           getters: getters,
           setters: setters);
     }

--- a/lib/src/compiler/base_transformer.dart
+++ b/lib/src/compiler/base_transformer.dart
@@ -28,7 +28,8 @@ class BaseTypeTransformer implements TypeTransformer {
     if (PRIMITIVES.contains(type)) return false;
 
     var list = _compiler.typeTransformers
-        .where((t) => t is StaticTypeTransformer && t.types.contains(type));
+        .where((t) => t is StaticTypeTransformer && t.types.contains(type))
+        .toList() as List<StaticTypeTransformer>;
     if (list.length == 0) return false;
 
     list.forEach((t) => t.staticTransformTo(_compiler, output, name, tree));
@@ -42,7 +43,8 @@ class BaseTypeTransformer implements TypeTransformer {
     if (PRIMITIVES.contains(type)) return false;
 
     var list = _compiler.typeTransformers
-        .where((t) => t is StaticTypeTransformer && t.types.contains(type));
+        .where((t) => t is StaticTypeTransformer && t.types.contains(type))
+        .toList() as List<StaticTypeTransformer>;
     if (list.length == 0) return false;
 
     list.forEach((t) => t.staticTransformFrom(_compiler, output, name, tree));
@@ -53,7 +55,6 @@ class BaseTypeTransformer implements TypeTransformer {
 
   transformTo(StringBuffer output, String name, tree) {
     if (tree is String) tree = _getTypeTree(tree);
-    if (tree is String) tree = [tree];
 
     var type = tree[0];
 
@@ -70,7 +71,6 @@ class BaseTypeTransformer implements TypeTransformer {
 
   transformFrom(StringBuffer output, String name, tree) {
     if (tree is String) tree = _getTypeTree(tree);
-    if (tree is String) tree = [tree];
 
     var type = tree[0];
 

--- a/lib/src/compiler/compiler.dart
+++ b/lib/src/compiler/compiler.dart
@@ -85,6 +85,11 @@ class Compiler {
         }
 
         if (type == "function" && isIncluded) {
+          if (childData["name"].startsWith("_"))
+          {
+            continue;
+          }
+          
           var params = _getParamsFromInfo(
               this,
               childData,

--- a/lib/src/compiler/compiler.dart
+++ b/lib/src/compiler/compiler.dart
@@ -25,6 +25,8 @@ class Compiler {
   List<String> globals = [];
 
   bool isMinified;
+  
+  List<String> includeDeclaration = [];
 
   Compiler(String dartFile, dynamic infoFile, dynamic mangledFile,
       {this.typeTransformers: const [],
@@ -52,6 +54,7 @@ class Compiler {
   }
 
   String compile(List<String> include) {
+    includeDeclaration = include;
     StringBuffer output = new StringBuffer();
     
     for (CompilerVisitor visitor in compilerVisitors) {
@@ -85,8 +88,7 @@ class Compiler {
         }
 
         if (type == "function" && isIncluded) {
-          if (childData["name"].startsWith("_"))
-          {
+          if (childData["name"].startsWith("_")) {
             continue;
           }
           

--- a/lib/src/transformers/buffer.dart
+++ b/lib/src/transformers/buffer.dart
@@ -8,7 +8,10 @@ part of calzone.transformers;
  * your stub file, and "dart.typed_data.ByteData" to your @MirrorsUsed
  * declaration.
  */
-class BufferTransformer implements TypeTransformer {
+class BufferTransformer implements TypeTransformer, NamedTypeTransformer {
+  final List<String> types = ["ByteData"];
+  final String output = "Buffer";
+  
   BufferTransformer();
 
   @override

--- a/lib/src/transformers/promise.dart
+++ b/lib/src/transformers/promise.dart
@@ -16,7 +16,7 @@ final String _PROMISE_PREFIX =
  */
 class PromiseTransformer implements TypeTransformer, NamedTypeTransformer {
   final List<String> types = ["Future"];
-  final String output = "Promise";
+  final String output = "Promise<any>";
   
   final bool _usePolyfill;
 

--- a/lib/src/transformers/promise.dart
+++ b/lib/src/transformers/promise.dart
@@ -14,7 +14,10 @@ final String _PROMISE_PREFIX =
  * be using a CommonJS/npm environment with the es6-promises package in your
  * package.json.
  */
-class PromiseTransformer implements TypeTransformer {
+class PromiseTransformer implements TypeTransformer, NamedTypeTransformer {
+  final List<String> types = ["Future"];
+  final String output = "Promise";
+  
   final bool _usePolyfill;
 
   PromiseTransformer([this._usePolyfill = false]);

--- a/lib/util.dart
+++ b/lib/util.dart
@@ -17,6 +17,11 @@ abstract class TypeTransformer {
   void transformFromDart(Compiler compiler, StringBuffer output);
 }
 
+abstract class NamedTypeTransformer {
+  List<String> get types;
+  String get output;
+}
+
 // for when types cannot be converted at runtime by dynamicTo/dynamicFrom
 abstract class StaticTypeTransformer {
   List<String> get types;

--- a/lib/visitor_typescript.dart
+++ b/lib/visitor_typescript.dart
@@ -1,0 +1,171 @@
+library calzone.visitor_typescript;
+
+import "package:analyzer/analyzer.dart" show ParameterKind;
+
+import "package:calzone/compiler.dart";
+import "package:calzone/util.dart";
+
+final Map<dynamic, String> _baseTypes = <String, String>{
+  null: "void",
+  "dynamic": "any",
+  "String": "string",
+  "bool": "boolean",
+  "int": "number",
+  "num": "number",
+  "Map": "any",
+  "LinkedHashMap": "any",
+  "Function": "any"
+};
+
+class _DualStringBuffer {
+  StringBuffer prefix = new StringBuffer();
+  StringBuffer content = new StringBuffer();
+  
+  _DualStringBuffer();
+  
+  writelnPrefix(String text) => prefix.writeln(text);
+  
+  writeln(String text) => content.writeln(text);
+  
+  String toString() {
+    if (prefix.isEmpty) {
+      return content.toString();
+    }
+    
+    return "${prefix}\n\n${content}";
+  }
+}
+
+class TypeScriptCompilerVisitor extends CompilerVisitor {
+  final String moduleName;
+  
+  String _output;
+  String get output => _output;
+  bool get hasOutput => _output != null;
+    
+  StringBuffer _buffer;
+  
+  _DualStringBuffer _classBuffer;
+  String _className;
+  
+  Map<dynamic, String> _types; 
+  
+  TypeScriptCompilerVisitor(this.moduleName);
+  
+  startCompilation(Compiler compiler) {
+    _buffer = new StringBuffer();
+    _buffer.writeln("declare namespace __$moduleName {");
+    
+    _types = new Map.from(_baseTypes);
+    
+    for (TypeTransformer transformer in compiler.typeTransformers) {
+      if (transformer is! NamedTypeTransformer)
+        continue;
+
+      var n = transformer as NamedTypeTransformer;
+      for (var input in n.types) {
+          _types[input] = n.output;
+      }
+    }
+  }
+  
+  stopCompilation() {
+    _buffer.writeln("""
+}
+      
+declare module "$moduleName" {
+\texport = __$moduleName;
+}
+    """);
+    
+    _output = _buffer.toString();
+    _buffer = null;
+  }
+  
+  String _handleType(String type) {
+    var tree = getTypeTree(type);
+
+    if (_types.containsKey(tree[0])) {
+      return _types[tree[0]];
+    }
+        
+    if (tree[0] == "List" || tree[0] == "Iterable") {
+      if (tree.length > 1) {
+        return "${_handleType(tree[1])}[]";
+      } else {
+        return "any[]";
+      }
+    }
+    
+    return tree[0];
+  }
+  
+  String _handleParams(List<Parameter> parameters) =>
+    parameters
+      .map((Parameter param) {
+        var suffix = param.kind == ParameterKind.POSITIONAL ? "?" : "";      
+        
+        return "${param.name}$suffix: ${_handleType(param.type)}";
+      })
+      .join(", ");
+  
+  String _makeFunction(Map<String, dynamic> data, List<Parameter> parameters, String returnType,
+      [String subName]) {
+    var name = subName != null ? subName : data["name"];
+    
+    returnType = _handleType(returnType);
+    var paramStr = _handleParams(parameters);
+    
+    return "$name($paramStr): $returnType;";
+  }
+  
+  addTopLevelFunction(Map<String, dynamic> data, List<Parameter> parameters, String returnType) {   
+    final str = _makeFunction(data, parameters, returnType); 
+    _buffer.writeln("\tfunction $str");
+  }
+  
+  startClass(Map<String, dynamic> data) {
+    _classBuffer = new _DualStringBuffer();
+    _className = data["name"];
+    
+    _classBuffer.writeln("\tclass ${data["name"]} {");
+  }
+  
+  stopClass() {
+    _classBuffer.writeln("\t}");
+    
+    _buffer.write("\n$_classBuffer");
+    _classBuffer = null;
+  }
+  
+  addClassConstructor(Map<String, dynamic> data, List<Parameter> parameters) {
+    _classBuffer.writeln("\t\tconstructor(${_handleParams(parameters)});");
+  }
+  
+  addClassStaticFunction(Map<String, dynamic> data, List<Parameter> parameters, String returnType) {
+    var name = data["name"].contains(_className + ".") ?
+      (data["name"] as String).substring(_className.length + 1) :
+      data["name"];
+    final str = _makeFunction(data, parameters, returnType, name); 
+    _classBuffer.writeln("\t\tstatic $str");
+  }
+  
+  addClassFunction(Map<String, dynamic> data, List<Parameter> parameters, String returnType) {
+    final str = _makeFunction(data, parameters, returnType); 
+    _classBuffer.writeln("\t\t$str");
+  }
+  
+  addClassStaticMember(Map<String, dynamic> data) {
+    final name = data["name"];
+    final type = data["type"];
+    
+    _classBuffer.writeln("\t\tstatic $name: ${_handleType(type)};");
+  }
+  
+  addClassMember(Map<String, dynamic> data) {
+    final name = data["name"];
+    final type = data["type"];
+    
+    _classBuffer.writeln("\t\t$name: ${_handleType(type)};");
+  }
+}

--- a/lib/visitor_typescript.dart
+++ b/lib/visitor_typescript.dart
@@ -12,10 +12,10 @@ final Map<dynamic, String> _baseTypes = <String, String>{
   "bool": "boolean",
   "int": "number",
   "num": "number",
-  "Map": "any",
   "DateTime": "Date",
+  "Function": "Function",
+  "Map": "any",
   "LinkedHashMap": "any",
-  "Function": "any",
   "Object": "any"
 };
 
@@ -76,6 +76,7 @@ class TypeScriptCompilerVisitor extends CompilerVisitor {
   String get output => _output;
   bool get hasOutput => _output != null;
     
+  Compiler _compiler;
   StringBuffer _buffer;
   
   _ClassStringBuffer _classBuffer;
@@ -85,6 +86,7 @@ class TypeScriptCompilerVisitor extends CompilerVisitor {
   TypeScriptCompilerVisitor(this.moduleName, { this.mixinTypes : "" });
   
   startCompilation(Compiler compiler) {
+    _compiler = compiler;
     _buffer = new StringBuffer();
     _buffer.writeln("declare namespace __$moduleName {");
     
@@ -132,6 +134,15 @@ declare module "$moduleName" {
         return "any[]";
       }
     }
+    
+    final obj = _compiler.analyzer.getClass(null, tree[0]);
+    if (obj == null)
+      return "any";
+      
+    if(!_compiler.includeDeclaration.contains(obj.libraryName + "." + tree[0]) &&
+        !_compiler.includeDeclaration.contains(obj.libraryName)) {
+      return "any";
+    }    
     
     return tree[0];
   }
@@ -183,7 +194,7 @@ declare module "$moduleName" {
   }
   
   addAbstractClass(Map<String, dynamic> data) {
-    _buffer.writeln("\n\tinterface ${data["name"]} {\n\t}");
+    _buffer.writeln("\n\tclass ${data["name"]} {\n\t}");
   }
   
   startClass(Map<String, dynamic> data, List<String> inheritedFrom) {

--- a/test/output_test.dart
+++ b/test/output_test.dart
@@ -71,11 +71,11 @@ Future setup() async {
       isMinified: true);
 
   var file = new File("test/temp/index.js");
-  file.writeAsStringSync(await builder.build());
+  await file.writeAsString(await builder.build());
   
   if (tsVisitor.hasOutput) {
     var tsFile = new File("test/temp/test.d.ts");
-    tsFile.writeAsStringSync(await tsVisitor.output);
+    await tsFile.writeAsString(tsVisitor.output);
   }
 
   var stdout = Process.runSync("node", ["test/output_test.js"]).stdout;

--- a/test/output_test.js
+++ b/test/output_test.js
@@ -113,7 +113,7 @@ describe('transformers.base', function() {
 });
 
 describe('inheritance', function() {
-  var _super = T.ClassTest.class;
+  var _super = T.ClassTest;
 
   function InheritanceTest() {
     _super.call(this);

--- a/test/test.dart
+++ b/test/test.dart
@@ -43,13 +43,23 @@ main() {
   });
 
   test("Class.inheritedFrom", () {
-    expect(analyzer.getClass("calzone.test.b", "D").inheritedFrom, equals([]));
-    expect(
-        analyzer.getClass("calzone.test.a", "C").inheritedFrom, equals(["D"]));
+    expect(analyzer.getClass("calzone.test.b", "D").inheritedFrom,
+        equals([]));
+    expect(analyzer.getClass("calzone.test.a", "C").inheritedFrom,
+        equals([]));
     expect(analyzer.getClass("calzone.test.a", "B").inheritedFrom,
-        equals(["C", "D"]));
+        equals(["C"]));
     expect(analyzer.getClass("calzone.test.a", "A").inheritedFrom,
-        equals(["B", "C", "D"]));
+        equals(["B", "C"]));
+  });
+  
+  test("Class.implementsFrom", () {
+    expect(analyzer.getClass("calzone.test.a", "C").implementsFrom,
+        equals(["D"]));
+    expect(analyzer.getClass("calzone.test.a", "B").implementsFrom,
+        equals([]));
+    expect(analyzer.getClass("calzone.test.a", "A").implementsFrom,
+        equals([]));
   });
 
   test("Class.getters", () {


### PR DESCRIPTION
- Added compiler visitors, basically a kind of limited AST visitor, with the use case in mind of creating additional bindings for the JS output, or analysis tools like a form of documentation just for JavaScript.

- Added a TypeScript compiler visitor. It will create a human-readable TypeScript definition file for the resulting node module. This was the main reason that compiler visitors were implemented.

- Fixed parsing bugs found while creating the TypeScript visitor. Also made a distinction between extends/with and implements in the analyzer AST visitor (different kind of visitor).

- Remove adding abstract classes to the JS binding output. This was broken, maybe add back the functionality later?